### PR TITLE
Nuget Feed & Iteration Fix

### DIFF
--- a/src/Sitecore.Configuration.Roles/RoleXmlPatchHelper.cs
+++ b/src/Sitecore.Configuration.Roles/RoleXmlPatchHelper.cs
@@ -81,17 +81,13 @@
       Assert.ArgumentNotNull(patch, "patch");
       Assert.ArgumentNotNull(ns, "ns");
 
-      var exit = false;
       string savedComment = null;
       var pendingOperations = new Stack<InsertOperation>();
 
       // copy child nodes
       foreach (IXmlElement node in patch.GetChildren())
       {
-        if (exit)
-        {
-          continue;
-        }
+        var exit = false;
 
         if (node.NodeType == XmlNodeType.Text)
         {

--- a/src/Sitecore.Configuration.Roles/Sitecore.Configuration.Roles.csproj
+++ b/src/Sitecore.Configuration.Roles/Sitecore.Configuration.Roles.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sitecore.Configuration.Roles</RootNamespace>
     <AssemblyName>Sitecore.Configuration.Roles</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -32,9 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Sitecore.Kernel, Version=8.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SC.Sitecore.Kernel.8.1.2\lib\Sitecore.Kernel.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Sitecore.Kernel, Version=10.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Sitecore.Kernel.NoReferences.8.2.170407\lib\NET452\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Sitecore.Configuration.Roles/packages.config
+++ b/src/Sitecore.Configuration.Roles/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="SC.Sitecore.Kernel" version="8.1.2" targetFramework="net45" />
+  <package id="Sitecore.Kernel.NoReferences" version="8.2.170407" targetFramework="net46" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
- Nuget feed updated to use package from Public Sitecore feed
- Fixed issue with node iteration, where presence of role:require attribute would cause the rest of the nodes in a patch file to be skipped.